### PR TITLE
Update gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gemspec
 
 gem 'kramdown-parser-gfm'
 gem 'webrick'
+
+gem 'rake', '12.3.3'
+gem 'jekyll-paginate-v2', '2.0.0'
+gem 'sassc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,8 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     webrick (1.8.1)
 
 PLATFORMS
@@ -70,10 +72,11 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
-  jekyll-paginate-v2 (~> 2.0)
+  jekyll-paginate-v2 (= 2.0.0)
   kramdown-parser-gfm
   phantom!
-  rake (~> 12.3)
+  rake (= 12.3.3)
+  sassc
   webrick
 
 BUNDLED WITH


### PR DESCRIPTION
Encountering an error when trying to serve a Jekyll site using Bundler. The specific error message is:

Could not find rake-12.3.3, jekyll-paginate-v2-2.0.0 in locally installed gems (Bundler::GemNotFound)

This means that the specified versions of rake and jekyll-paginate-v2 gems are not installed in the current environment.

Fix:

1. Install Missing Gems
2. Update Ruby Sass